### PR TITLE
Avoid errors on incorrectly defined properties

### DIFF
--- a/Classes/AssetUsageIndex.php
+++ b/Classes/AssetUsageIndex.php
@@ -198,7 +198,7 @@ final class AssetUsageIndex implements \Countable
         if ($value instanceof ResourceBasedInterface) {
             return [$this->getAssetId($value)];
         }
-        if ($type === 'string' || is_subclass_of($type, Stringable::class)) {
+        if (is_string($value) || is_subclass_of($type, Stringable::class)) {
             preg_match_all('/asset:\/\/(?<assetId>[\w-]*)/i', (string)$value, $matches, PREG_SET_ORDER);
             return array_map(static fn (array $match) => $match['assetId'], $matches);
         }

--- a/Classes/AssetUsageIndex.php
+++ b/Classes/AssetUsageIndex.php
@@ -198,7 +198,7 @@ final class AssetUsageIndex implements \Countable
         if ($value instanceof ResourceBasedInterface) {
             return [$this->getAssetId($value)];
         }
-        if (is_string($value) || is_subclass_of($type, Stringable::class)) {
+        if (is_string($value) || $value instanceof Stringable) {
             preg_match_all('/asset:\/\/(?<assetId>[\w-]*)/i', (string)$value, $matches, PREG_SET_ORDER);
             return array_map(static fn (array $match) => $match['assetId'], $matches);
         }


### PR DESCRIPTION
When is not defined correctly (without a type), it is assumed a type of `string`. That leads to the error reported in #2.

This fixes that by checking for the actual type of the `$value`.

Fixes: #2